### PR TITLE
Add option to run without re-inits on success

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,12 @@ mv staging pluto-0.38.sysroot
 cd pluto-msk-application
 # copy msk_top_regs.h from firmware build to this directory
 
-arm-linux-gnueabihf-gcc -mfloat-abi=hard --sysroot=$HOME/pluto-0.38.sysroot -g -D ENDLESS_PRBS -D RF_LOOPBACK -o msk_test-xmit msk_test.c -lpthread -liio -lm -Wall -Wextra && arm-linux-gnueabihf-gcc -mfloat-abi=hard --sysroot=$HOME/pluto-0.38.sysroot -g -D ENDLESS_PRBS -D RX_ACTIVE -o msk_test-recv msk_test.c -lpthread -liio -lm -Wall -Wextra
+arm-linux-gnueabihf-gcc -mfloat-abi=hard --sysroot=$HOME/pluto-0.38.sysroot -g -D ENDLESS_PRBS -D NO_INIT_ON_SUCCESS -D RF_LOOPBACK -o msk_test-xmit msk_rx_init.c -lpthread -liio -lm -Wall -Wextra && arm-linux-gnueabihf-gcc -mfloat-abi=hard --sysroot=$HOME/pluto-0.38.sysroot -g -D ENDLESS_PRBS -D NO_INIT_ON_SUCCESS -D RX_ACTIVE -o msk_test-recv msk_rx_init.c -lpthread -liio -lm -Wall -Wextra
 # The above line builds two versions of the application.
 # The `xmit` version has `RF_LOOPBACK` enabled; it transmits PRBS forever.
 # The `recv` version has `RX_ACTIVE` enabled; it does not transmit.
 # Both versions try to receive and validate the data using PRBS Mon.
+# Both versions continue to run without re-inits if all is going well.q
 ```
 
 Notes:

--- a/msk_rx_init.c
+++ b/msk_rx_init.c
@@ -62,6 +62,7 @@
 //#define RX_ACTIVE
 //#define RF_LOOPBACK
 //#define ENDLESS_PRBS
+//#define NO_INIT_ON_SUCCESS
 
 #if defined (RX_ACTIVE) && defined (RF_LOOPBACK)
 #error "RX_ACTIVE and RF_LOOPBACK both defined is not valid."
@@ -912,8 +913,8 @@ int main (int argc, char **argv)
 		printf("-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-\n");
 
 		spectacular_success++;
-//		printf("spectactular_success = %d\n", spectacular_success);
-//		if(false) {  //use this for no test for spectacular success
+
+#ifndef NO_INIT_ON_SUCCESS
 		if(spectacular_success > 20) {
 			spectacular_success = 0;
 			printf("Paul, we had a good run.\n");
@@ -931,6 +932,7 @@ int main (int argc, char **argv)
 
 			break;
 		}
+#endif
 	} //end of while percent_error < 49.0
 
 


### PR DESCRIPTION
Up to now we have limited the duration of a successful (BER = 0) run, because we wanted to change PI gains and start again. But sometimes we just want to transmit and receive successfully for a long duration. Now NO_INIT_ON_SUCCESS can be defined to get that behavior.