### PR TITLE
Settable sampling interval

### DIFF
--- a/msk_rx_init.c
+++ b/msk_rx_init.c
@@ -80,6 +80,8 @@
 #error "STREAMING and ENDLESS_PRBS both undefined, not sure what to do."
 #endif
 
+#define TX_SYNC_CTRL_WORD 0x00000000
+#define TX_SYNC_COUNT (54200 * 20)	// long preamble for test detection
 
 #define TX_DMAC_CONTROL_REGISTER 0x00
 #define TX_DMAC_STATUS_REGISTER 0x04
@@ -461,6 +463,17 @@ int main (int argc, char **argv)
 	printf("Reading from MSK block HASH ID LOW: (0x%08x@%04x)\n", READ_MSK(Hash_ID_Low), OFFSET_MSK(Hash_ID_Low));
 	printf("Reading from MSK block HASH ID HIGH: (0x%08x@%04x)\n", READ_MSK(Hash_ID_High), OFFSET_MSK(Hash_ID_High));
 	printf("-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-\n");
+
+
+	printf("-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-\n");
+	printf("Configure the TX_SYNC_CTRL register to 0x%08x.\n", TX_SYNC_CTRL_WORD);
+	WRITE_MSK(Tx_Sync_Ctrl, TX_SYNC_CTRL_WORD);
+	printf("Reading TX_SYNC_CTRL. We see: (0x%08x@%04x)\n", READ_MSK(Tx_Sync_Ctrl), OFFSET_MSK(Tx_Sync_Ctrl));
+	printf("Configure the TX_SYNC_CNT register to TX_SYNC_COUNT bit times.\n");
+	WRITE_MSK(Tx_Sync_Cnt, TX_SYNC_COUNT);
+	printf("Reading TX_SYNC_CNT. We see: (0x%08x@%04x)\n", READ_MSK(Tx_Sync_Cnt), OFFSET_MSK(Tx_Sync_Cnt));
+	printf("-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-\n");
+
 
 	printf("Initialize MSK block.\n");
 	printf("Read MSK_INIT: (0x%08x@%04x)\n", READ_MSK(MSK_Init), OFFSET_MSK(MSK_Init));

--- a/msk_rx_init.c
+++ b/msk_rx_init.c
@@ -109,6 +109,9 @@ int i; //index variable for loops
 /* Global Timer runs on the CPU clock, divided by 2 */
 #define COUNTS_PER_SECOND (666666687 / 2 / 2)
 static uint32_t *timer_register_map;
+/* Collect telementry and make decisions after this duration */
+#define REPORTING_INTERVAL (COUNTS_PER_SECOND / 1000)
+
 
 //read from a memory mapped register
 unsigned int read_dma(unsigned int *virtual_addr, int offset)
@@ -718,7 +721,7 @@ int main (int argc, char **argv)
 	while(!stop) {
 	#endif
 
-	uint64_t reporting_interval = COUNTS_PER_SECOND;							// reporting period = one second
+	uint64_t reporting_interval = REPORTING_INTERVAL;
 	uint64_t next_reporting_timestamp = get_timestamp() + reporting_interval;	// report status periodically starting now
 
 	while(percent_error > 0.1){


### PR DESCRIPTION
Parameterize the duration of each sampling period.

Preliminary testing suggests values down to about 0.01 seconds are feasible.